### PR TITLE
Force attribute sync on update when not using custom attributes

### DIFF
--- a/geoserver/resource_geoserver_featuretype.go
+++ b/geoserver/resource_geoserver_featuretype.go
@@ -158,7 +158,7 @@ func resourceGeoserverFeatureType() *schema.Resource {
 }
 
 func resourceGeoserverFeatureTypeCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] Creating Geoserver FeatureType: %s", d.Id())
+	log.Printf("[INFO] Creating Geoserver FeatureType: %s", d.Get("name").(string))
 
 	client := meta.(*Config).GeoserverClient()
 
@@ -388,7 +388,8 @@ func resourceGeoserverFeatureTypeUpdate(d *schema.ResourceData, meta interface{}
 		Metadata:   metadata,
 	}
 
-	err := client.UpdateFeatureType(workspaceName, datastoreName, featureTypeName, featureType)
+	sync_attributes := !d.Get("use_custom_attributes").(bool)
+	err := client.UpdateFeatureType(workspaceName, datastoreName, featureTypeName, featureType, sync_attributes)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/camptocamp/terraform-provider-geoserver
 
-replace github.com/camptocamp/go-geoserver => /home/agacon/camptocamp/go-geoserver
-
 go 1.15
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/camptocamp/terraform-provider-geoserver
 
+replace github.com/camptocamp/go-geoserver => /home/agacon/camptocamp/go-geoserver
+
 go 1.15
 
 require (
-	github.com/camptocamp/go-geoserver v0.0.0-20231220144753-e3d59d348b48
+	github.com/camptocamp/go-geoserver v0.0.0-20240205195341-221dfa93f919
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 )

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/camptocamp/go-geoserver v0.0.0-20231215143954-f99a84dadc4c h1:OUukvFT
 github.com/camptocamp/go-geoserver v0.0.0-20231215143954-f99a84dadc4c/go.mod h1:z5s93Ll45psIP40hoVWpQPservcqeX4MOQDLV+Ys4rE=
 github.com/camptocamp/go-geoserver v0.0.0-20231220144753-e3d59d348b48 h1:x8yl62xEuSkKCidZi6AtjYVcb704kiW1LAN0j3Xtufo=
 github.com/camptocamp/go-geoserver v0.0.0-20231220144753-e3d59d348b48/go.mod h1:z5s93Ll45psIP40hoVWpQPservcqeX4MOQDLV+Ys4rE=
+github.com/camptocamp/go-geoserver v0.0.0-20240205195341-221dfa93f919 h1:D+SK80n6S2aJ7zfUhwH7a0wIBLOc+YBlGCB45Q1HxZc=
+github.com/camptocamp/go-geoserver v0.0.0-20240205195341-221dfa93f919/go.mod h1:z5s93Ll45psIP40hoVWpQPservcqeX4MOQDLV+Ys4rE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=


### PR DESCRIPTION
Participate to resolve issue #30 . It is up to the terraform configuration maintainer to trigger an update of the feature type to activate the attribute sync.